### PR TITLE
fix: Add go mod init

### DIFF
--- a/solutions/go-helloworld/Dockerfile
+++ b/solutions/go-helloworld/Dockerfile
@@ -3,8 +3,8 @@ FROM golang:alpine
 WORKDIR /go/src/app
 
 ADD . .
-
-RUN go build  -o helloworld
+RUN go mod init
+RUN go build -o helloworld
 
 EXPOSE 6111
 


### PR DESCRIPTION
Add `RUN go mod init` to the docker file in `solutions/go-helloworld`